### PR TITLE
141 bug background images moving on filter close

### DIFF
--- a/src/lib/component/Filter.svelte
+++ b/src/lib/component/Filter.svelte
@@ -139,9 +139,9 @@
     margin: 0;
   }
 
-  /*quick fix wilol soolve later in general styling*/
+  /*if its not broken, don't fix it!!*/
    input[type="checkbox"]:focus + label {
-    outline: 2px solid #ff0; 
+    outline: 2px solid var(--primary-color-hover); 
     outline-offset: 2px;
   }
 
@@ -149,6 +149,7 @@
     display: none;
     margin: 0;
     padding: 0;
+    height: 0;
     height: 0;
     opacity: 0;
 

--- a/src/lib/component/Filter.svelte
+++ b/src/lib/component/Filter.svelte
@@ -1,6 +1,6 @@
 <script>
-  import { onMount } from "svelte";
   let { tags } = $props();
+  import { onMount } from "svelte";
   import image from "$lib/assets/filter-bg.svg";
 
   onMount(() => {
@@ -26,7 +26,7 @@
   });
 </script>
 
-<div class="toggle-filter filter-button">
+<div class="toggle-filter button">
   <input class="checker" type="checkbox" id="filter-toggle" value="Filter" />
   <label for="filter-toggle">Filter</label>
 </div>
@@ -101,22 +101,6 @@
   /* This CSS doesn't yet include variables since it is based of older dev branch -> will be included very soon!! */
 
   /* adding this to general css */
-  .filter-button {
-    margin-top: 1em;
-    border-radius: 3em;
-    padding: 3em 1em;
-    border: none;
-    background-color: var(--green-main-hover);
-    padding-block: 1em;
-    padding-inline: 3em;
-    cursor: pointer;
-    color: var(--background-color);
-
-    &:hover {
-      background-color: var(--green-secondary);
-      /* color: var(--background-icon-color); */
-    }
-  }
 
   .toggle-filter {
     position: relative;
@@ -271,4 +255,5 @@
     border-radius: 15px;
     z-index: 1;
   }
+
 </style>

--- a/src/lib/component/product.svelte
+++ b/src/lib/component/product.svelte
@@ -39,6 +39,7 @@
         box-sizing: var(--inner-spacing);
 		width: 16rem;
 		height: 26rem;
+		overflow: hidden;
 
 			/* Link: bekijk product */
 			a {
@@ -59,8 +60,8 @@
 
 			h3 {
 				font-size: clamp(--h3-font-size);
-				height: 4rem;
 				color: var(--text-color);
+				text-overflow: ellipsis;
 			}
 
 			img {

--- a/src/lib/styles/style.css
+++ b/src/lib/styles/style.css
@@ -45,7 +45,7 @@
     --font-weight-bold: 700;
     --font-weight-extra-bold: 800;
 
-    --h1-font-size: clamp(2.5rem, 5vw, 4rem);
+    --h1-font-size: clamp(2.1rem, 5vw, 4rem);
     --h2-font-size: clamp(2rem, 4vw, 2.8rem);
     --h3-font-size: clamp(1.2rem, 3vw, 1.3em);
 
@@ -186,3 +186,19 @@ a {
 a, button, input, select {
     cursor: var(--cursor-hover);
 }
+
+.button {
+      margin-top: 1em;
+      border-radius: 3em;
+      border: none;
+      background-color: var(--accent-color);
+      padding-block: 1em;
+      padding-inline: 3em;
+      cursor: pointer;
+      color: var(--text-color-button);
+
+      &:hover {
+        background-color: var(--accent-color-light);
+        /* color: var(--background-icon-color); */
+      }
+    }

--- a/src/lib/styles/style.css
+++ b/src/lib/styles/style.css
@@ -45,9 +45,9 @@
     --font-weight-bold: 700;
     --font-weight-extra-bold: 800;
 
-    --h1-font-size: clamp(2rem, 5vw, 4rem);
-    --h2-font-size: clamp(1.5rem, 4vw, 3rem);
-    --h3-font-size: clamp(1.2rem, 3vw, 1.4rem);
+    --h1-font-size: clamp(2.5rem, 5vw, 4rem);
+    --h2-font-size: clamp(2rem, 4vw, 2.8rem);
+    --h3-font-size: clamp(1.2rem, 3vw, 1.3em);
 
     --text-font-size-s: clamp(1rem, 2vw, 1.5rem);
     --text-font-size-m: clamp(1.25rem, 2.5vw, 1.75rem);

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -1,5 +1,4 @@
 <script>
-	
 	import { Header } from '$lib';
 	import favicon from '$lib/assets/favicon.svg';
 	import '$lib/styles/style.css';

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -29,6 +29,8 @@
 
 
 <main>
+  
+  <h2>Producten</h2>
   <ul>
     {#each products as product}
       <Product {product} />
@@ -40,6 +42,8 @@
   main {
     display: grid;
     justify-content: center;
+    align-items: center;
+    text-align: center;
   }
 
   ul {
@@ -50,7 +54,6 @@
     gap: 2em;
     max-width: 80rem;
     padding: 0;
-    margin-top: 4rem;
     padding-inline: 1rem;
 
     @media (min-width: 912px) {

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -18,10 +18,8 @@
   <svg width="213" height="250" viewBox="0 0 213 250" fill="none" xmlns="http://www.w3.org/2000/svg"><path opacity="0.04" d="M174.64 194.693C169.462 194.306 164.145 195.704 159.88 199.099C155.553 202.543 152.699 207.73 151.971 214.161C150.703 225.359 151.735 235.026 156.474 241.681C161.661 248.964 169.99 251.009 179.049 249.567C187.849 248.166 193.04 242.043 195.569 235.666C198.005 229.525 198.301 222.522 197.151 217.078C195.008 203.455 185.108 195.476 174.64 194.693ZM167.479 208.552C169.118 207.248 171.32 206.584 173.728 206.764C178.385 207.113 183.886 210.716 185.151 219.07L185.181 219.266L185.224 219.46C185.949 222.765 185.767 227.406 184.254 231.222C182.804 234.878 180.493 237.078 177.127 237.614C170.98 238.592 168.056 237.006 166.4 234.681C164.296 231.726 162.895 225.807 164.06 215.517C164.463 211.962 165.9 209.809 167.479 208.552ZM133.104 136.724L137.581 183.667H162.882V171.561H148.646L145.215 135.581L133.104 136.724ZM81.3547 140.516L83.827 152.368L99.946 149.039L97.4737 137.187L81.3547 140.516ZM171.131 123.413L178.355 133.153L191.129 123.772L183.904 114.031L171.131 123.413ZM-1.52588e-05 44.5476L82.4198 102.655L89.4529 92.7778L7.03305 34.6704L-1.52588e-05 44.5476ZM70.5723 26.6793L109.197 82.9709L119.244 76.1449L80.6194 19.8533L70.5723 26.6793ZM132.156 20.8918L148.579 71.4332L160.153 67.7081L143.73 17.1667L132.156 20.8918ZM190.925 68.7L202.964 70.4413L213 1.74138L200.962 0L190.925 68.7Z" fill="black"/></svg>
 
   <form action="">
-    <div class="input-wrap">
       <input type="search" name="chatbot"  placeholder="search a gift for a dreamer" />
       <input type="image" src="{robotimg}" border="0" alt="Submit"  width="36" height="36" />
-    </div>
   </form>
 
   <Filter {tags} />
@@ -88,6 +86,11 @@
         bottom: 50vh;
         scale: 0.6;
 
+        /*max width for easier styling*/
+        @media (max-width:650px){
+          display: none;
+        }
+
         @media (min-width: 1050px){
           bottom: 5em;
         }
@@ -106,53 +109,41 @@
     }
 
     form {
-      display: grid;
+      position: relative;
       row-gap: 1em;
       grid-template-columns: 4fr 1fr;
       grid-template-rows: 3fr 2fr;
       border-radius: 3em;
-      padding: 0.15em;
-      width: 18em;
-
-      svg {
-        width: 2.5em;
-        margin-left: -3em;
-        pointer-events: none;
-        grid-column: 3;
-        grid-row: 1;
-      }
+      width: clamp(15em, 80vw, 20em);
     }
 
     input:first-of-type {
       border: none;
-      padding-left: 1.5em;
+
+      padding:1.5em 1em 1.5em 2em;
       width: 100%;
       /* max-width: 80%; */
-      padding-right: 4em;
       border: 2px solid transparent;
       border-radius: 3em;
       background:
         linear-gradient(white, white) padding-box,
         linear-gradient(45deg, red, purple, gold, blue);
-      grid-column: 1/-1;
-      grid-row: 1;
     }
 
     input:nth-of-type(2) {
-      grid-column: span 2;
-      justify-self: center;
-      padding-inline: 2em;
+      position: absolute;
+      top: 0.5em;
+      right: 1.5em;
       border-radius: 3em;
-      border: none;
-      background-color: var(--accent-color);
+      padding: 0.2em;
+      border: 2px solid var(--accent-color);
       &:hover {
         background-color: var(--accent-color-hover);
       }
     }
 
     input[type="search"]::-webkit-search-cancel-button {
-      position: relative;
-      transform: translateX(0.5em);
+      opacity: 0;
     }
 
     button {
@@ -171,22 +162,6 @@
       }
     }
 
-    
-    button {
-      margin-top: 1em;
-      border-radius: 3em;
-      border: none;
-      background-color: var(--accent-color);
-      padding-block: 1em;
-      padding-inline: 3em;
-      cursor: pointer;
-      color: var(--text-color-button);
-
-      &:hover {
-        background-color: var(--accent-color-light);
-        /* color: var(--background-icon-color); */
-      }
-    }
 
     p {
       color: var(--text-color-chat);

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -3,7 +3,7 @@
   import image from "$lib/assets/filter-bg.svg";
   import robotimg from "$lib/assets/chatbot.svg"
 
-  //import products component
+ 
   import { Product } from "$lib";
   import { Filter } from "$lib";
 
@@ -57,8 +57,8 @@
     padding-inline: 1rem;
 
     @media (min-width: 912px) {
-            padding-inline: 2rem;
-        }
+      padding-inline: 2rem;
+    }
   }
 
   .filters {
@@ -71,21 +71,21 @@
     overflow: hidden;
 
     > svg {
-      position: absolute;
+      position: fixed;
       z-index: -1;
 
       &:nth-of-type(1) {
-        left: 5em;
-        top: 2em;
+        left: 3em;
+        top: 5vh;
       }
 
       &:nth-of-type(2) {
-        right: 5em;
-        bottom: 0;
-        display: none;
+        right: 3em;
+        bottom: 5vh;
+        opacity: 0;
 
-        @media (min-width: 650px) {
-          display: block;
+        @media (min-width: 950px) {
+          opacity: 1;
         }
       }
     }
@@ -109,9 +109,8 @@
       padding: 0.15em;
       width: 18em;
 
-      svg {
+      input[type="image"] {
         width: 2.5em;
-        margin-left: -3em;
         pointer-events: none;
         grid-column: 3;
         grid-row: 1;

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -76,7 +76,7 @@
 
       &:nth-of-type(1) {
         left: 3em;
-        top: 10vh;
+        top: 15vh;
       }
 
       &:nth-of-type(2) {

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -76,7 +76,7 @@
 
       &:nth-of-type(1) {
         left: 3em;
-        top: 5vh;
+        top: 10vh;
       }
 
       &:nth-of-type(2) {

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -3,7 +3,7 @@
   import image from "$lib/assets/filter-bg.svg";
   import robotimg from "$lib/assets/chatbot.svg"
 
- 
+  //import products component
   import { Product } from "$lib";
   import { Filter } from "$lib";
 
@@ -18,8 +18,10 @@
   <svg width="213" height="250" viewBox="0 0 213 250" fill="none" xmlns="http://www.w3.org/2000/svg"><path opacity="0.04" d="M174.64 194.693C169.462 194.306 164.145 195.704 159.88 199.099C155.553 202.543 152.699 207.73 151.971 214.161C150.703 225.359 151.735 235.026 156.474 241.681C161.661 248.964 169.99 251.009 179.049 249.567C187.849 248.166 193.04 242.043 195.569 235.666C198.005 229.525 198.301 222.522 197.151 217.078C195.008 203.455 185.108 195.476 174.64 194.693ZM167.479 208.552C169.118 207.248 171.32 206.584 173.728 206.764C178.385 207.113 183.886 210.716 185.151 219.07L185.181 219.266L185.224 219.46C185.949 222.765 185.767 227.406 184.254 231.222C182.804 234.878 180.493 237.078 177.127 237.614C170.98 238.592 168.056 237.006 166.4 234.681C164.296 231.726 162.895 225.807 164.06 215.517C164.463 211.962 165.9 209.809 167.479 208.552ZM133.104 136.724L137.581 183.667H162.882V171.561H148.646L145.215 135.581L133.104 136.724ZM81.3547 140.516L83.827 152.368L99.946 149.039L97.4737 137.187L81.3547 140.516ZM171.131 123.413L178.355 133.153L191.129 123.772L183.904 114.031L171.131 123.413ZM-1.52588e-05 44.5476L82.4198 102.655L89.4529 92.7778L7.03305 34.6704L-1.52588e-05 44.5476ZM70.5723 26.6793L109.197 82.9709L119.244 76.1449L80.6194 19.8533L70.5723 26.6793ZM132.156 20.8918L148.579 71.4332L160.153 67.7081L143.73 17.1667L132.156 20.8918ZM190.925 68.7L202.964 70.4413L213 1.74138L200.962 0L190.925 68.7Z" fill="black"/></svg>
 
   <form action="">
-    <input type="search" placeholder="search a gift for a dreamer" />
-    <input type="image" src="{robotimg}" border="0" alt="Submit"  width="36" height="36" />
+    <div class="input-wrap">
+      <input type="search" name="chatbot"  placeholder="search a gift for a dreamer" />
+      <input type="image" src="{robotimg}" border="0" alt="Submit"  width="36" height="36" />
+    </div>
   </form>
 
   <Filter {tags} />
@@ -29,8 +31,6 @@
 
 
 <main>
-  
-  <h2>Producten</h2>
   <ul>
     {#each products as product}
       <Product {product} />
@@ -42,8 +42,6 @@
   main {
     display: grid;
     justify-content: center;
-    align-items: center;
-    text-align: center;
   }
 
   ul {
@@ -54,11 +52,12 @@
     gap: 2em;
     max-width: 80rem;
     padding: 0;
+    margin-top: 4rem;
     padding-inline: 1rem;
 
     @media (min-width: 912px) {
-      padding-inline: 2rem;
-    }
+            padding-inline: 2rem;
+        }
   }
 
   .filters {
@@ -75,18 +74,23 @@
       z-index: -1;
 
       &:nth-of-type(1) {
-        left: 3em;
-        top: 15vh;
+        left: 5em;
+        top: 15em;
+        display: none;
+
+        @media (min-width: 1050px) {
+          display: block;
+        }
       }
 
       &:nth-of-type(2) {
-        right: 3em;
-        bottom: 5vh;
-        opacity: 0;
+        right: 5em;
+        bottom: 50vh;
 
-        @media (min-width: 950px) {
-          opacity: 1;
+        @media (min-width: 1050px){
+          bottom: 5em;
         }
+        
       }
     }
 
@@ -109,8 +113,9 @@
       padding: 0.15em;
       width: 18em;
 
-      input[type="image"] {
+      svg {
         width: 2.5em;
+        margin-left: -3em;
         pointer-events: none;
         grid-column: 3;
         grid-row: 1;
@@ -165,9 +170,27 @@
       }
     }
 
+    
+    button {
+      margin-top: 1em;
+      border-radius: 3em;
+      border: none;
+      background-color: var(--accent-color);
+      padding-block: 1em;
+      padding-inline: 3em;
+      cursor: pointer;
+      color: var(--text-color-button);
+
+      &:hover {
+        background-color: var(--accent-color-light);
+        /* color: var(--background-icon-color); */
+      }
+    }
+
     p {
       color: var(--text-color-chat);
       margin: 0;
     }
   }
+  
 </style>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -84,8 +84,9 @@
       }
 
       &:nth-of-type(2) {
-        right: 5em;
+        right: 0;
         bottom: 50vh;
+        scale: 0.6;
 
         @media (min-width: 1050px){
           bottom: 5em;


### PR DESCRIPTION
## What does this change?

The background has now been set to fixed. This way the background doesn't move on opening and closing the filter and even stays in place to fill up the empty background on the rest of the page

Resolves issue #1337

## How Has This Been Tested?

- [ ] [User test]()
- [ ] [Accessibility test]()
- [ ] [Performance test]()
- [x] [Responsive Design test]()
- [x] [Device test]()
- [x] [Browser test]()

## Images

<img width="2506" height="1388" alt="Screenshot 2025-11-25 154041" src="https://github.com/user-attachments/assets/ea56aea9-812f-4ea0-ae90-494d4dd4d025" />
<img width="2514" height="1230" alt="Screenshot 2025-11-25 154051" src="https://github.com/user-attachments/assets/7331836f-2fe9-4a4d-9ed5-029a3b908a5b" />
<img width="2514" height="1386" alt="Screenshot 2025-11-25 154059" src="https://github.com/user-attachments/assets/fb5d2cfb-e718-4c5b-baa8-4bc375a7a37a" />



## How to review

Test on different devices to make sure to position of the svg is correct at all times.