### PR TITLE
Bug] fix grid layout

### DIFF
--- a/src/lib/component/Filter.svelte
+++ b/src/lib/component/Filter.svelte
@@ -27,7 +27,7 @@
 </script>
 
 <div class="toggle-filter button">
-  <input class="checker" type="checkbox" id="filter-toggle" value="Filter" />
+  <input class="checker" type="checkbox" id="filter-toggle" value="Filter" checked/>
   <label for="filter-toggle">Filter</label>
 </div>
 

--- a/src/lib/component/product.svelte
+++ b/src/lib/component/product.svelte
@@ -5,25 +5,30 @@
 <li>
 	<a tabindex="-1" href="/"><img class="product-img" loading="lazy" src="{product.image}" alt="test" width="200" height="200"></a>
 	<h3>{product.name}</h3>
-	<a class="bekijk-product-btn" href="/">Bekijk product
-		<img loading="lazy" src="/images/right-arrow.svg" alt="" width="14" height="14" />
-	</a>
-	<form action="/" method="post">
-		<button id="likeBtn" type="submit" aria-label="Like">
-		  <svg width="30" height="30" viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg" fill="#212121">
-			<path d="M10.5,8v2C9.122,10,8,11.121,8,12.5H6C6,10.019,8.019,8,10.5,8z" />
-			<path d="M21.5,5c-2.116,0-4.093,0.881-5.5,2.406C14.593,5.881,12.616,5,10.5,5C6.364,5,3,8.333,3,12.5C3,21.542,16,27,16,27s13-5.458,13-14.5C29,8.333,25.636,5,21.5,5z M16,24.797C13.378,23.521,5,18.938,5,12.5C5,9.467,7.467,7,10.5,7c1.55,0,2.982,0.626,4.03,1.762l0.735,0.797h1.47l0.735-0.797C18.518,7.626,19.95,7,21.5,7c3.033,0,5.5,2.467,5.5,5.5C27,18.938,18.622,23.521,16,24.797z" />
-		  </svg>
-		</button>
-		<label for="likeBtn">like</label>
-	</form>
+
+	<div>
+		<a class="bekijk-product-btn" href="/">Bekijk product
+			<img loading="lazy" src="/images/right-arrow.svg" alt="" width="14" height="14" />
+		</a>
+
+		<form action="/" method="post">
+			<button id="likeBtn" type="submit" aria-label="Like">
+			<svg width="30" height="30" viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg" fill="#212121">
+				<path d="M10.5,8v2C9.122,10,8,11.121,8,12.5H6C6,10.019,8.019,8,10.5,8z" />
+				<path d="M21.5,5c-2.116,0-4.093,0.881-5.5,2.406C14.593,5.881,12.616,5,10.5,5C6.364,5,3,8.333,3,12.5C3,21.542,16,27,16,27s13-5.458,13-14.5C29,8.333,25.636,5,21.5,5z M16,24.797C13.378,23.521,5,18.938,5,12.5C5,9.467,7.467,7,10.5,7c1.55,0,2.982,0.626,4.03,1.762l0.735,0.797h1.47l0.735-0.797C18.518,7.626,19.95,7,21.5,7c3.033,0,5.5,2.467,5.5,5.5C27,18.938,18.622,23.521,16,24.797z" />
+			</svg>
+			</button>
+			<label for="likeBtn">like</label>
+		</form>
+
+	</div>
 </li>
 
 <style>
 	li {
 		display: grid;
 		grid-template-rows: subgrid;
-		grid-row: span 4;
+		grid-row: span 3;
 		background-color: var(--neutral-color-background-cards);
 		gap: var(--spacing-xs);
 		place-items: baseline;

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -47,14 +47,25 @@
     text-align: center;
   }
 
-  ul {
+ ul {
     display: grid;
     grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
-    gap: var(--spacing-m);
-    width: 100vw;
+     gap: 5rem 1rem;
+    width: 90vw;
     list-style: none;
     box-sizing: border-box;
     padding: var(--spacing-m);
+    container-type: inline-size;
+  }
+
+  /* this fixes the problem of li not working with nested css  */
+  ul > :global(li):nth-child(odd) {
+    transform: translateY(0rem);
+     
+
+    @container (width > 1000px) {
+      transform: translateY(2rem);
+    }
   }
 
   .filters {


### PR DESCRIPTION
## What does this change?

Masonry layout fixed, cards smaller due to better use of subgrid and filter is now closed by standard (mobile as well, mobile will be fixed later).


## How Has This Been Tested?

- [ ] [User test]()
- [ ] [Accessibility test]()
- [ ] [Performance test]()
- [x] [Responsive Design test]()
- [x] [Device test]()
- [x] [Browser test]()

## Images


<img width="2438" height="1036" alt="Screenshot 2025-12-18 114719" src="https://github.com/user-attachments/assets/003402bd-fd72-4b2e-b66f-832a12d04c69" />
<img width="1470" height="879" alt="Screenshot 2025-12-18 114732" src="https://github.com/user-attachments/assets/916d2b33-608a-4efa-ba2f-632cef1dd5e0" />


